### PR TITLE
[Hotfix]: SecurityConfig.java 파일에 ** 문법 오류로 GetMethod 조회 불가능. 삭제 후 정상…

### DIFF
--- a/src/main/java/com/sparta/harmony/common/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/harmony/common/config/SecurityConfig.java
@@ -78,7 +78,6 @@ public class SecurityConfig {
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
                         .requestMatchers("/").permitAll() // 메인 페이지 요청 허가
                         .requestMatchers("/api/users/**", "api/reviews/**").permitAll() // '/api/user/'로 시작하는 요청 모두 접근 허가
-                        .requestMatchers(HttpMethod.GET, "/api/stores/**/menus/**").permitAll()
                         .requestMatchers("/swagger-ui", "/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**", "/webjars/**", "/swagger-ui.html").permitAll()
                         .anyRequest().authenticated() // 그 외 모든 요청 인증처리
         ).exceptionHandling(accessDeniedHandler ->


### PR DESCRIPTION
[Hotfix]: SecurityConfig.java 파일에 ** 문법 오류로 GetMethod 조회 불가능. 삭제 후 정상 조회 확인.